### PR TITLE
Fix the name of network_G in train_Ensemble_AGCM_LE.yml

### DIFF
--- a/codes/options/train/train_Ensemble_AGCM_LE.yml
+++ b/codes/options/train/train_Ensemble_AGCM_LE.yml
@@ -33,7 +33,7 @@ datasets:
 
 #### network structures
 network_G:
-  which_model_G: Ensemble_AGCN_LE
+  which_model_G: Ensemble_AGCM_LE
   classifier: color_condition
   cond_c: 6
   in_nc: 3


### PR DESCRIPTION
## Summary

Fix the name of network_G in train_Ensemble_AGCM_LE.yml: Ensemble_AGCN_LE->Ensemble_AGCM_LE. "Ensemble_AGCN_LE" will lead to training errors.